### PR TITLE
Run Travis JavaScript tests on separated Matrix Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 env:
   global:
     - RUN_PHPCS="no"
+    - RUN_JAVASCRIPT_TESTS="no"
     - INSTALL_MEMCACHE="yes"
     - INSTALL_MEMCACHED="yes"
     - INSTALL_REDIS="yes"
@@ -19,7 +20,7 @@ matrix:
     - php: 5.6
       env: RUN_PHPCS="yes" INSTALL_APCU="yes"
     - php: 7.0
-      env: INSTALL_APCU="yes" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
+      env: RUN_JAVASCRIPT_TESTS="yes" INSTALL_APCU="yes" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
     - php: 7.1
       env: INSTALL_APCU="yes" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
     - php: hhvm
@@ -79,12 +80,11 @@ before_script:
   #Make sure all node modules are installed
   - cd tests/javascript
   - npm install
-  - cd ../..
 
 script:
   - libraries/vendor/bin/phpunit --configuration travisci-phpunit.xml
   - if [[ $RUN_PHPCS == "yes" ]]; then libraries/vendor/bin/phpcs --report=full --extensions=php -p --standard=build/phpcs/Joomla .; fi
-  - tests/javascript/node_modules/karma/bin/karma start karma.conf.js --single-run
+  - if [[ $RUN_JAVASCRIPT_TESTS == "yes" ]]; then tests/javascript/node_modules/karma/bin/karma start karma.conf.js --single-run ; fi
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ services:
 
 before_script:
   # JavaScript tests
-  - if [[ $RUN_JAVASCRIPT_TESTS == "yes" ]]; then bash tests/javascript/travis-tests.sh $PWD; exit 0; fi
+  - if [[ $RUN_JAVASCRIPT_TESTS == "yes" ]]; then export DISPLAY=:99.0; bash tests/javascript/travis-tests.sh $PWD; exit 0; fi
   # Make sure all dev dependencies are installed
   - composer install
   # Set up databases for testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
   fast_finish: true
   include:
     - node_js: 6.1
+      sudo: true
       env: RUN_JAVASCRIPT_TESTS="yes"
     - php: 5.3
       env: INSTALL_APC="yes"

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ services:
 
 before_script:
   # JavaScript tests
-  - if [[ $RUN_JAVASCRIPT_TESTS == "yes" ]]; then export DISPLAY=:99.0; bash tests/javascript/travis-tests.sh $PWD; exit 0; fi
+  - if [[ $RUN_JAVASCRIPT_TESTS == "yes" ]]; then export DISPLAY=:99.0; bash tests/javascript/travis-tests.sh $PWD; fi
   # Make sure all dev dependencies are installed
   - composer install
   # Set up databases for testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ services:
 
 before_script:
   # JavaScript tests
-  - if [[ $RUN_JAVASCRIPT_TESTS == "yes" ]]; then ./tests/javascript/travis-tests.sh $PWD; exit 0; fi
+  - if [[ $RUN_JAVASCRIPT_TESTS == "yes" ]]; then bash tests/javascript/travis-tests.sh $PWD; exit 0; fi
   # Make sure all dev dependencies are installed
   - composer install
   # Set up databases for testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,8 @@ services:
   - redis-server
 
 before_script:
-  - BASE=$PWD
+  # JavaScript tests
+  - if [[ $RUN_JAVASCRIPT_TESTS == "yes" ]]; then sudo ./tests/javascript/travis-tests.sh $PWD; exit 0; fi
   # Make sure all dev dependencies are installed
   - composer install
   # Set up databases for testing
@@ -71,19 +72,6 @@ before_script:
   - if [[ $INSTALL_APCU_BC_BETA == "yes" ]]; then printf "\n" | pecl install apcu_bc-beta; fi
   - if [[ $INSTALL_REDIS == "yes" && $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-add build/travis/phpenv/redis.ini; fi
   - if [[ $INSTALL_REDIS == "yes" && $TRAVIS_PHP_VERSION = hhvm ]]; then cat build/travis/phpenv/redis.ini >> /etc/hhvm/php.ini; fi
-  # Xvfb
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
-  # Fluxbox
-  - sudo apt-get update -qq
-  - sudo apt-get install -y --force-yes firefox fluxbox
-  - fluxbox &
-  - sleep 3 # give fluxbox some time to start
-  #Make sure all node modules are installed
-  - cd tests/javascript
-  - npm install
-  - cd $BASE
 
 script:
   - libraries/vendor/bin/phpunit --configuration travisci-phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ services:
   - redis-server
 
 before_script:
+  - BASE=$PWD
   # Make sure all dev dependencies are installed
   - composer install
   # Set up databases for testing
@@ -80,6 +81,7 @@ before_script:
   #Make sure all node modules are installed
   - cd tests/javascript
   - npm install
+  - cd $BASE
 
 script:
   - libraries/vendor/bin/phpunit --configuration travisci-phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ services:
 
 before_script:
   # JavaScript tests
-  - if [[ $RUN_JAVASCRIPT_TESTS == "yes" ]]; then sudo ./tests/javascript/travis-tests.sh $PWD; exit 0; fi
+  - if [[ $RUN_JAVASCRIPT_TESTS == "yes" ]]; then ./tests/javascript/travis-tests.sh $PWD; exit 0; fi
   # Make sure all dev dependencies are installed
   - composer install
   # Set up databases for testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
 matrix:
   fast_finish: true
   include:
+    - node_js: 6.1
+      env: RUN_JAVASCRIPT_TESTS="yes"
     - php: 5.3
       env: INSTALL_APC="yes"
     - php: 5.4
@@ -20,7 +22,7 @@ matrix:
     - php: 5.6
       env: RUN_PHPCS="yes" INSTALL_APCU="yes"
     - php: 7.0
-      env: RUN_JAVASCRIPT_TESTS="yes" INSTALL_APCU="yes" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
+      env: INSTALL_APCU="yes" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
     - php: 7.1
       env: INSTALL_APCU="yes" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
     - php: hhvm

--- a/tests/javascript/travis-tests.sh
+++ b/tests/javascript/travis-tests.sh
@@ -6,8 +6,7 @@ BASE="$1"
 set -e
 
 # Xvfb
-"export DISPLAY=:99.0"
-"sh -e /etc/init.d/xvfb start"
+sh -e /etc/init.d/xvfb start
 sleep 3 # give xvfb some time to start
 
 # Fluxbox

--- a/tests/javascript/travis-tests.sh
+++ b/tests/javascript/travis-tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Script for installing firefox and fluxbox and preparing JavaScript tests
+
+BASE="$1"
+
+# Xvfb
+"export DISPLAY=:99.0"
+"sh -e /etc/init.d/xvfb start"
+sleep 3 # give xvfb some time to start
+
+# Fluxbox
+sudo apt-get update -qq
+sudo apt-get install -y --force-yes firefox fluxbox
+fluxbox &
+sleep 3 # give fluxbox some time to start
+
+#Make sure all node modules are installed
+cd tests/javascript
+npm install
+cd $BASE

--- a/tests/javascript/travis-tests.sh
+++ b/tests/javascript/travis-tests.sh
@@ -15,7 +15,6 @@ sudo apt-get install -y --force-yes firefox fluxbox
 fluxbox &
 sleep 3 # give fluxbox some time to start
 
-#Make sure all node modules are installed
+# Install node modules for tests
 cd tests/javascript
 npm install
-cd $BASE

--- a/tests/javascript/travis-tests.sh
+++ b/tests/javascript/travis-tests.sh
@@ -3,6 +3,8 @@
 
 BASE="$1"
 
+set -e
+
 # Xvfb
 "export DISPLAY=:99.0"
 "sh -e /etc/init.d/xvfb start"


### PR DESCRIPTION
As the PHP version does not influence our tests there is no reason to run it every time.

I kept the installation of the virtual xserver, Firefox and Fluxbox for now.
